### PR TITLE
Fixes overflowing subtraction in get_neighbors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -535,9 +535,9 @@ impl Grid {
     fn get_neighbors(&self, pos: (u32, u32)) -> [Option<&Square>; 4] {
         [
             self.get_at((pos.0 + 1, pos.1)),
-            self.get_at((pos.0 - 1, pos.1)),
+            pos.0.checked_sub(1).and_then(|it| self.get_at((it, pos.1))),
             self.get_at((pos.0, pos.1 + 1)),
-            self.get_at((pos.0, pos.1 - 1)),
+            pos.1.checked_sub(1).and_then(|it| self.get_at((pos.0, it))),
         ]
     }
 }


### PR DESCRIPTION
Cool project! Found a small bug and fixed it, functional style. Would occur if the board is full and game_over condition is checked.